### PR TITLE
Bug.MDD143 - Fix for function "create_certificate" deadlock Bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - VERSION=1.2-alpine
   - VERSION=1.3-alpine
   - VERSION=1.4-alpine
+  - VERSION=1.5-alpine
   # legacy
   - VERSION=1.0.0-alpine
   - VERSION=1.0.1-alpine

--- a/.travis/tagging.sh
+++ b/.travis/tagging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Set an option to exit immediately if any error appears
-set -xv
+set -xe
 
 echo  "### Show Images before Tagging:"
 docker images

--- a/.travis/tagging.sh
+++ b/.travis/tagging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Set an option to exit immediately if any error appears
-set -xe
+set -xv
 
 echo  "### Show Images before Tagging:"
 docker images
@@ -30,7 +30,7 @@ unset IFS
 LATEST=$(echo ${sorted[$index-1]}|cut -d- -f 1)
 
 # All Latest Major Versions
-MAJOR_LATEST
+MAJOR_LATEST=""
 # Run over all FOLDER versions and add all first digit numbers
 for i in ${sorted[@]}
 do

--- a/1.5-alpine/files/entrypoint_nginx.sh
+++ b/1.5-alpine/files/entrypoint_nginx.sh
@@ -34,7 +34,19 @@ function SSL_generate_cert(){
 }
 
 function SSL_generate_DH(){
-    [ ! -f $SSL_DH_FILE ] && echo "Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048
+    # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
+    i=0
+    while [ -f $PID_CERT_CREATER.server ]
+    do
+        echo "`date +%T` -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+        i=$((i+1))
+        sleep 2
+        [ "$i" -eq 30 ] && rm $PID_CERT_CREATER.server
+        # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+    done
+    
+    [ ! -f $SSL_DH_FILE ] && touch $PID_CERT_CREATER.proxy && echo "Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 

--- a/1.5-alpine/files/entrypoint_nginx.sh
+++ b/1.5-alpine/files/entrypoint_nginx.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+STARTMSG="[ENTRYPOINT_APACHE]"
+
 SSL_DH_FILE="/etc/nginx/ssl/dhparams.pem"
 SSL_KEY="/etc/nginx/ssl/key.pem"
 SSL_CERT="/etc/nginx/ssl/cert.pem"
@@ -20,7 +22,7 @@ function SSL_generate_cert(){
     i=0
     while [ -f $PID_CERT_CREATER.server ]
     do
-        echo "`date +%T` -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        echo "$STARTMSG `date +%T` -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
         # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
         i=$((i+1))
         sleep 2
@@ -28,7 +30,7 @@ function SSL_generate_cert(){
         # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
     done
     
-    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER.proxy && echo "Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj '/CN='${HOSTNAME} -nodes && echo "finished." && rm $PID_CERT_CREATER.proxy
+    [ ! -f $SSL_CERT -a ! -f $SSL_KEY ] && touch $PID_CERT_CREATER.proxy && echo "$STARTMSG Create SSL Certificate..." && openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj '/CN='${HOSTNAME} -nodes && rm $PID_CERT_CREATER.proxy
     
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
@@ -38,7 +40,7 @@ function SSL_generate_DH(){
     i=0
     while [ -f $PID_CERT_CREATER.server ]
     do
-        echo "`date +%T` -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        echo "$STARTMSG `date +%T` -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
         # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
         i=$((i+1))
         sleep 2
@@ -46,7 +48,7 @@ function SSL_generate_DH(){
         # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
     done
     
-    [ ! -f $SSL_DH_FILE ] && touch $PID_CERT_CREATER.proxy && echo "Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
+    [ ! -f $SSL_DH_FILE ] && touch $PID_CERT_CREATER.proxy && echo "$STARTMSG Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
@@ -102,7 +104,7 @@ echo # add an echo command because if no command is done busybox (alpine sh) won
 
 function file_maintenance_html(){
 
-[ ! -d $MAINTENANCE_HTML_PATH ] && echo "mkdir -p $MAINTENANCE_HTML_PATH" && mkdir -p $MAINTENANCE_HTML_PATH; # Add directory for maintenance File + Copy Maintenance config
+[ ! -d $MAINTENANCE_HTML_PATH ] && echo "$STARTMSG mkdir -p $MAINTENANCE_HTML_PATH" && mkdir -p $MAINTENANCE_HTML_PATH; # Add directory for maintenance File + Copy Maintenance config
 
 cat << EOF > $MAINTENANCE_HTML_FILE
 <!doctype html>
@@ -130,16 +132,16 @@ echo
 
 function enable_maintenance(){
     # deactivate https
-    [ -f $HTTPS_CONFIG.conf ] && echo "mv $HTTPS_CONFIG.conf $HTTPS_CONFIG" && mv $HTTPS_CONFIG.conf $HTTPS_CONFIG
-    [ -f $MAINTENANCE ] && echo "mv $MAINTENANCE $MAINTENANCE.conf" && mv $MAINTENANCE $MAINTENANCE.conf
+    [ -f $HTTPS_CONFIG.conf ] && echo "$STARTMSG mv $HTTPS_CONFIG.conf $HTTPS_CONFIG" && mv $HTTPS_CONFIG.conf $HTTPS_CONFIG
+    [ -f $MAINTENANCE ] && echo "$STARTMSG mv $MAINTENANCE $MAINTENANCE.conf" && mv $MAINTENANCE $MAINTENANCE.conf
     nginx -t
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
     exit
 }
 
 function disable_maintenance(){
-    [ -f $HTTPS_CONFIG ] && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
-    [ -f $MAINTENANCE.conf ] && mv $MAINTENANCE.conf $MAINTENANCE
+    [ -f $HTTPS_CONFIG ] && echo "$STARTMSG mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
+    [ -f $MAINTENANCE.conf ] && echo "$STARTMSG mv $MAINTENANCE.conf $MAINTENANCE" && mv $MAINTENANCE.conf $MAINTENANCE
     nginx -t
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
     exit
@@ -162,14 +164,14 @@ function upgrade(){
             echo "Folder $i is on the newest version."
         else
             # upgrade
-            echo "Folder $i should be updated."
+            echo "$STARTMSG Folder $i should be updated."
             case $(echo $i/$NAME) in
             1.4)
                 # Tasks todo in 2.4.92
-                echo "#### Upgrade Volumes from 2.4.92 ####"
+                echo $STARTMSG "#### Upgrade Volumes from 2.4.92 ####"
                 ;;
             *)
-                echo "Unknown Version, upgrade not possible."
+                echo "$STARTMSG Unknown Version, upgrade not possible."
                 exit
                 ;;
             esac
@@ -191,7 +193,7 @@ SSL_generate_DH
 # create maintenance file
 file_maintenance_html
 # check volumes and upgrade if it is required
-echo "upgrade if it is required..." && upgrade
+echo "$STARTMSG upgrade if it is required..." && upgrade
 
 # activate maintenance
 [ "$1" == "enable-maintenance" ] && enable_maintenance

--- a/1.5-alpine/files/entrypoint_nginx.sh
+++ b/1.5-alpine/files/entrypoint_nginx.sh
@@ -183,17 +183,17 @@ function upgrade(){
 
 #####################   MAIN    ###################
 # generate vars_common
-file_vars_common
+echo "$STARTMSG Create variables file..." && file_vars_common
 # generate global_allow_IPs
-file_GLOBAL_allow_IPs "$IP"
+echo "$STARTMSG Create file for IP restrictions..." && file_GLOBAL_allow_IPs "$IP"
 # check if ssl cert is required to generate
-SSL_generate_cert
+echo "$STARTMSG Check if cert is required..." && SSL_generate_cert
 # check if DH file is required to generate
-SSL_generate_DH
+echo "$STARTMSG Check if DH is required..." && SSL_generate_DH
 # create maintenance file
-file_maintenance_html
+echo "$STARTMSG Create maintenance file..." && file_maintenance_html
 # check volumes and upgrade if it is required
-echo "$STARTMSG upgrade if it is required..." && upgrade
+echo "$STARTMSG check if upgrade is required..." && upgrade
 
 # activate maintenance
 [ "$1" == "enable-maintenance" ] && enable_maintenance

--- a/1.5-alpine/files/nginx/conf.d/SERVER_HTTPS_and_redirected_HTTP.conf
+++ b/1.5-alpine/files/nginx/conf.d/SERVER_HTTPS_and_redirected_HTTP.conf
@@ -14,7 +14,6 @@ server {
 
 	include conf.d/vars_common;
 
-	# SSL Certificate and Key
 	ssl_certificate /etc/nginx/ssl/cert.pem;
 	ssl_certificate_key /etc/nginx/ssl/key.pem;
 

--- a/1.5-alpine/files/nginx/conf.d/misp_vars_proxy
+++ b/1.5-alpine/files/nginx/conf.d/misp_vars_proxy
@@ -20,6 +20,10 @@ proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header Accept-Encoding "";
 proxy_set_header Connection "";
 
+proxy_buffering off;
+proxy_request_buffering off;
+proxy_intercept_errors on;
+
 # Determines whether SSL sessions can be reused when working with the proxied server. 
 # If the errors “SSL3_GET_FINISHED:digest check failed” appear in the logs, 
 # try disabling session reuse. Default:
@@ -40,3 +44,4 @@ proxy_read_timeout 300;
 # The value can contain variables.
 # If the always parameter is specified (1.7.5), the header field will be added regardless of the response code
 add_header Cache-Control "public, must-revalidate";
+


### PR DESCRIPTION
## Changelog for bug.MDD143 - Fix for function "create_certificate" deadlock Bug
### Update Informations 
Proxy version 1.4-alpine creates a file to prevent the misp-server from creating its own certificate. This should be deleted once the creation is complete. Unfortunately the proxy with verison 1.4-alpine interrupted the script before removing the file. Therefore it has not been deleted anymore. Since only one file was used for both the proxy and the misp-server this bug has the consequence that the apache2 entrypoint of the misp-server version 2.4.97-2.4.99 is also deadlocked.

### General Changes
No general changes were made.

### Fixes & Improvements
- Added a new misp-proxy version 1.5 with a own pid file for misp-server and misp-proxy.

### Detailed Changes
- We have added an additional pid file. So we now have one that creates the misp-proxy and queries the misp-server and one that is created by the misp-server and queries the misp-proxy. Its own file can overwrite both the proxy and the server. Therefore such deadlocks should be a thing of the past in the future.
- We have added an echo tagging for entrypoint script echo output.