### PR TITLE
Bug/MDD 226: MISP Proxy Version 1 (1.5-alpine) can not start with MISP-dockerized 1.0.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,9 @@ notify:
 variables:
   COMPONENT: proxy
 
+.build:
+  when: manual
+
 include:
   - project: 'MISP/helper-containers'
     ref: master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,4 +19,5 @@ include:
   - '1.3-alpine/.gitlab-ci.yml'
   - '1.4-alpine/.gitlab-ci.yml'
   - '1.5-alpine/.gitlab-ci.yml'
+  - '1.6-alpine/.gitlab-ci.yml'
   - '2.0-alpine/.gitlab-ci.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - FOLDER=1.3-alpine
   - FOLDER=1.4-alpine
   - FOLDER=1.5-alpine
+  - FOLDER=1.6-alpine
   - FOLDER=2.0-alpine
   
 script:
@@ -29,6 +30,6 @@ script:
                       "$TRAVIS_BUILD_DIR/$FOLDER"
 
 
-# don't notify me when things fail
-notifications:
-  email: false
+# # don't notify me when things fail
+# notifications:
+#   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 
 env:
   global:
-  #- DOCKER_COMPOSE_VERSION=1.4.2
   - COMPONENT=proxy
 
   matrix:
@@ -17,17 +16,44 @@ env:
   - FOLDER=1.3-alpine
   - FOLDER=1.4-alpine
   - FOLDER=1.5-alpine
-  - FOLDER=1.6-alpine
-  - FOLDER=2.0-alpine
+  - FOLDER=1.6-alpine ADD_TAG="1-dev"
+  - FOLDER=2.0-alpine ADD_TAG="2-dev latest-dev"
   
+
+before_install:
+# Pull Kaniko Image
+- docker pull gcr.io/kaniko-project/executor:latest
+# Login to hub.docker.com
+- echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
+
+install:
+# Add docker-retag executable
+- wget -q https://github.com/joshdk/docker-retag/releases/download/0.0.2/docker-retag && chmod +x docker-retag
+
 script:
-- docker build -f "$TRAVIS_BUILD_DIR/$FOLDER/Dockerfile" 
-                      --build-arg VCS_REF="$TRAVIS_COMMIT" 
-                      --build-arg VERSION="$FOLDER" 
-                      --build-arg GIT_REPO="https://github.com/$TRAVIS_REPO_SLUG" 
-                      --build-arg COMPONENT="$COMPONENT"
-                      --build-arg BUILD_DATE="$(date -u +"%Y-%m-%d")"
-                      "$TRAVIS_BUILD_DIR/$FOLDER"
+# Build Image via kaniko
+- docker run
+    -v "$TRAVIS_BUILD_DIR/$FOLDER":/workspace
+    -v $HOME/.docker:/kaniko/.docker
+  gcr.io/kaniko-project/executor:latest
+    --context=/workspace
+    --build-arg VCS_REF=$TRAVIS_COMMIT
+    --build-arg VERSION=$FOLDER
+    --build-arg GIT_REPO=https://github.com/$TRAVIS_REPO_SLUG
+    --build-arg COMPONENT=$COMPONENT
+    --build-arg BUILD_DATE=$(date -u +"%Y-%m-%d")
+    --verbosity=info
+    --destination=$DOCKER_SLUG/misp-dockerized-$COMPONENT:$FOLDER
+
+# Retag images for other tags
+- for i in $ADD_TAG;
+  do
+    ./docker-retag $DOCKER_SLUG/misp-dockerized-$COMPONENT:$FOLDER $i;
+  done
+
+# # don't notify me when things fail
+# notifications:
+#   email: false
 
 
 # # don't notify me when things fail

--- a/1.5-alpine/.gitlab-ci.yml
+++ b/1.5-alpine/.gitlab-ci.yml
@@ -4,7 +4,7 @@ build 1.5-alpine:
   variables:
     FOLDER: "1.5-alpine"
     VERSION: "$FOLDER"
-    TAGS: "${FOLDER}-dev 1-dev"
+    TAGS: "${FOLDER}-dev"
     RELEASE_DATE: 2018-12
   
 test 1.5-alpine:

--- a/1.6-alpine/.gitlab-ci.yml
+++ b/1.6-alpine/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+
+build 1.6-alpine:
+  extends: .build
+  variables:
+    FOLDER: "1.6-alpine"
+    VERSION: "$FOLDER"
+    TAGS: "${FOLDER}-dev 1-dev"
+    RELEASE_DATE: 2019-07
+  
+test 1.6-alpine:
+  extends: .test
+  variables:
+    FOLDER: "1.6-alpine"
+    VERSION: "$FOLDER"
+    TAGS: "${FOLDER}-dev"
+    RELEASE_DATE: 2019-07
+  only:
+    changes:
+    - 1.6-alpine/*

--- a/1.6-alpine/Dockerfile
+++ b/1.6-alpine/Dockerfile
@@ -1,0 +1,77 @@
+FROM nginx:stable-alpine
+
+
+#     Variables for Labels:
+ARG VENDOR="DCSO GmbH"
+ARG COMPONENT="proxy"
+ARG BUILD_DATE
+ARG GIT_REPO
+ARG VCS_REF
+ARG VERSION
+ARG RELEASE_DATE
+ARG NAME="MISP-dockerized-${COMPONENT}"
+ARG DESCRIPTION="This docker container is part of the DCSO MISP dockerized environment."
+ARG DOCUMENTATION="https://github.com/DCSO/MISP-dockerized"
+ARG AUTHOR="DCSO MISP Docker Team <misp.docker@dcso.de>"
+ARG LICENSE="BSD-3-Clause"
+#     END Variables
+
+#########################################
+LABEL org.label-schema.build-date="${BUILD_DATE}" \
+        org.label-schema.name="${NAME}" \
+        org.label-schema.description="${DESCRIPTION}" \
+        org.label-schema.vcs-ref="${VCS_REF}" \
+        org.label-schema.vcs-url="${GIT_REPO}" \
+        org.label-schema.url="${GIT_REPO}" \
+        org.label-schema.vendor="${VENDOR}" \
+        org.label-schema.version="${VERSION}" \
+        org.label-schema.usage="${DOCUMENTATION}" \
+        org.label-schema.schema-version="1.0.0-rc1"
+
+LABEL   org.opencontainers.image.created="${BUILD_DATE}" \
+        org.opencontainers.image.url="${GIT_REPO}" \
+        org.opencontainers.image.source="${GIT_REPO}" \
+        org.opencontainers.image.version="${VERSION}" \
+        org.opencontainers.image.revision="${VCS_REF}" \
+        org.opencontainers.image.vendor="${VENDOR}" \
+        org.opencontainers.image.title="${NAME}" \
+        org.opencontainers.image.description="${DESCRIPTION}" \
+        org.opencontainers.image.documentation="${DOCUMENTATION}" \
+        org.opencontainers.image.authors="${AUTHOR}" \
+        org.opencontainers.image.licenses="${LICENSE}"
+#########################################
+
+
+# Install Curl for Healthcheck
+RUN apk add --no-cache \
+    curl \
+    openssl
+
+# Copy the NGINX configs
+COPY files/nginx/conf.d/* /etc/nginx/conf.d/
+# COPY Entrypoint script
+COPY files/entrypoint_nginx.sh /
+RUN chmod +x /entrypoint_nginx.sh
+
+# rename orig nginx.conf && place own nginx.conf
+RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.orig \
+    && ln -s /etc/nginx/conf.d/GLOBAL_nginx_common /etc/nginx/nginx.conf \
+    && rm -f /etc/nginx/conf.d/default.conf
+
+# create self signed cert
+RUN mkdir -p /etc/nginx/ssl;
+
+# Environment Variable for Proxy
+ENV HTTP_PROXY=""
+ENV HTTPS_PROXY=""
+ENV NO_PROXY="0.0.0.0"
+# Environment Variable to check Version
+ENV NAME ${NAME}
+ENV VERSION ${VERSION}
+ENV RELEASE_DATE ${RELEASE_DATE}
+
+# Add Healthcheck Config
+HEALTHCHECK --interval=2m --timeout=15s --retries=3 CMD curl -fk https://localhost/ || exit 1
+
+
+ENTRYPOINT [ "/entrypoint_nginx.sh" ]

--- a/1.6-alpine/files/entrypoint_nginx.sh
+++ b/1.6-alpine/files/entrypoint_nginx.sh
@@ -1,0 +1,217 @@
+#!/bin/sh
+set -e
+
+STARTMSG="[ENTRYPOINT_APACHE]"
+
+SSL_DH_FILE="/etc/nginx/ssl/dhparams.pem"
+SSL_KEY="/etc/nginx/ssl/key.pem"
+SSL_CERT="/etc/nginx/ssl/cert.pem"
+VARS_COMMON="/etc/nginx/conf.d/vars_common"
+GLOBAL_allow_IPs=/etc/nginx/conf.d/GLOBAL_allow_IPs
+HTTPS_CONFIG="/etc/nginx/conf.d/SERVER_HTTPS_and_redirected_HTTP"
+HTTP_CONFIG="/etc/nginx/conf.d/SERVER_HTTP_only"
+MAINTENANCE="/etc/nginx/conf.d/SERVER_MAINTENANCE"
+PID_CERT_CREATER="/etc/nginx/ssl/SSL_create.pid"
+MAINTENANCE_HTML_PATH="/var/www/maintenance"
+MAINTENANCE_HTML_FILE="$MAINTENANCE_HTML_PATH/index.html"
+FOLDER_with_VERSIONS="/etc/nginx/ssl /etc/nginx/conf.d"
+
+# shellcheck disable=SC2039
+MISP_FQDN=${MISP_FQDN:-"$HOSTNAME"}
+CLIENT_MAX_BODY_SIZE=${PROXY_CLIENT_MAX_BODY_SIZE:-"50M"}
+
+SSL_generate_cert(){
+    # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
+    i=0
+    while [ -f "$PID_CERT_CREATER.server" ]
+    do
+        echo "$STARTMSG $(date +%T) -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+        i=$((i+1))
+        sleep 2
+        [ "$i" -eq 30 ] && rm "$PID_CERT_CREATER.server"
+        # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+    done
+    
+    if [ ! -f "$SSL_CERT" ] && [ ! -f "$SSL_KEY" ]; then
+        touch "$PID_CERT_CREATER.proxy" && echo "$STARTMSG Create SSL Certificate..." 
+        openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/C=DE/CN=${MISP_FQDN}" -nodes 
+        rm $PID_CERT_CREATER.proxy
+    fi
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+SSL_generate_DH(){
+    # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
+    i=0
+    while [ -f "$PID_CERT_CREATER.server" ]
+    do
+        echo "$STARTMSG $(date +%T) -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+        i=$((i+1))
+        sleep 2
+        [ "$i" -eq 30 ] && rm $PID_CERT_CREATER.server
+        # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
+    done
+    
+    [ ! -f "$SSL_DH_FILE" ] && touch $PID_CERT_CREATER.proxy && echo "$STARTMSG Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+deactivate_http_config(){
+    [ -f "$HTTP_CONFIG.conf" ] && echo "mv $HTTP_CONFIG.conf $HTTP_CONFIG" && mv $HTTP_CONFIG.conf $HTTP_CONFIG
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+activate_https_config()
+{
+    [ -f "$HTTPS_CONFIG" ] && echo "mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+file_GLOBAL_allow_IPs(){
+IP="$1"
+
+
+if [ -z "$IP" ]
+then
+    # If no param is given allow all IP
+cat << EOF > "$GLOBAL_allow_IPs"
+allow all;
+EOF
+else
+    # If param is given include only the valid ips
+[ -f "$GLOBAL_allow_IPs" ] && rm "$GLOBAL_allow_IPs"
+
+for i in $IP
+do
+cat << EOF >> "$GLOBAL_allow_IPs"
+allow $i;
+EOF
+done
+
+fi
+
+
+chmod 644 "$GLOBAL_allow_IPs"
+echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+file_vars_common()
+{  
+cat << EOF > $VARS_COMMON
+server_name $MISP_FQDN;
+client_max_body_size $CLIENT_MAX_BODY_SIZE;
+
+EOF
+chmod 644 "$VARS_COMMON"
+echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+}
+
+file_maintenance_html(){
+
+[ ! -d $MAINTENANCE_HTML_PATH ] && echo "$STARTMSG mkdir -p $MAINTENANCE_HTML_PATH" && mkdir -p $MAINTENANCE_HTML_PATH; # Add directory for maintenance File + Copy Maintenance config
+
+cat << EOF > $MAINTENANCE_HTML_FILE
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:${HTTP_SERVERADMIN}?Subject=MISP-dockerized Maintenance at ${MISP_FQDN}">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; Your MISP Support Team</p>
+    </div>
+</article>
+
+EOF
+echo
+}
+
+enable_maintenance(){
+    # deactivate https
+    [ -f "$HTTPS_CONFIG.conf" ] && echo "$STARTMSG mv $HTTPS_CONFIG.conf $HTTPS_CONFIG" && mv $HTTPS_CONFIG.conf $HTTPS_CONFIG
+    [ -f "$MAINTENANCE" ] && echo "$STARTMSG mv $MAINTENANCE $MAINTENANCE.conf" && mv $MAINTENANCE $MAINTENANCE.conf
+    nginx -t
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    exit
+}
+
+disable_maintenance(){
+    [ -f "$HTTPS_CONFIG" ] && echo "$STARTMSG mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
+    [ -f "$MAINTENANCE.conf" ] && echo "$STARTMSG mv $MAINTENANCE.conf $MAINTENANCE" && mv $MAINTENANCE.conf $MAINTENANCE
+    nginx -t
+    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    exit
+}
+
+# upgrade(){
+#     for i in $FOLDER_with_VERSIONS
+#     do
+#         if [ ! -f "$i/${NAME}" ] 
+#         then
+#             # File not exist and now it will be created
+#             echo "${VERSION}" > "$i/${NAME}"
+#         elif [ ! -f "$i/${NAME}" ] && [ -z "$(cat "$i/${NAME}")" ]
+#         then
+#             # File exists, but is empty
+#             echo "${VERSION}" > "$i/${NAME}"
+#         elif [ "$VERSION" = "$(cat "$i/${NAME}")" ]
+#         then
+#             # File exists and the volume is the current version
+#             echo "Folder $i is on the newest version."
+#         else
+#             # upgrade
+#             echo "$STARTMSG Folder $i should be updated."
+#             case "$i/$NAME" in
+#             "1.4")
+#                 # Tasks todo in 2.4.92
+#                 echo "#### Upgrade Volumes from 2.4.92 ####"
+#                 ;;
+#             *)
+#                 echo "Unknown Version, upgrade not possible."
+#                 exit
+#                 ;;
+#             esac
+#             ############ DO ANY!!!
+#         fi
+#     done
+#     echo
+# }
+
+#####################   MAIN    ###################
+# generate vars_common
+echo "$STARTMSG Create variables file..." && file_vars_common
+# generate global_allow_IPs
+echo "$STARTMSG Create file for IP restrictions..." && file_GLOBAL_allow_IPs "$IP"
+# check if ssl cert is required to generate
+echo "$STARTMSG Check if cert is required..." && SSL_generate_cert
+# check if DH file is required to generate
+echo "$STARTMSG Check if DH is required..." && SSL_generate_DH
+# create maintenance file
+echo "$STARTMSG Create maintenance file..." && file_maintenance_html
+# check volumes and upgrade if it is required
+#echo "$STARTMSG check if upgrade is required..." && upgrade
+
+# activate maintenance
+[ "$1" = "enable-maintenance" ] && enable_maintenance
+
+# deactivate maintenance
+[ "$1" = "disable-maintenance" ] && disable_maintenance
+
+# test nginx config
+nginx -t
+
+# if no param is given
+[ -z "$1" ] && exec nginx -g "daemon off;"
+
+# execute any COMMAND
+exec "$@"

--- a/1.6-alpine/files/entrypoint_nginx.sh
+++ b/1.6-alpine/files/entrypoint_nginx.sh
@@ -20,6 +20,10 @@ FOLDER_with_VERSIONS="/etc/nginx/ssl /etc/nginx/conf.d"
 MISP_FQDN=${MISP_FQDN:-"$HOSTNAME"}
 CLIENT_MAX_BODY_SIZE=${PROXY_CLIENT_MAX_BODY_SIZE:-"50M"}
 
+echo() {
+    command echo "$STARTMSG $*"
+}
+
 SSL_generate_cert(){
     # If a valid SSL certificate is not already created for the server, create a self-signed certificate:
     i=0
@@ -29,14 +33,14 @@ SSL_generate_cert(){
         # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
         i=$((i+1))
         sleep 2
-        [ "$i" -eq 30 ] && rm "$PID_CERT_CREATER.server"
+        [ "$i" -eq 30 ] && rm -v "$PID_CERT_CREATER.server"
         # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
     done
     
     if [ ! -f "$SSL_CERT" ] && [ ! -f "$SSL_KEY" ]; then
-        touch "$PID_CERT_CREATER.proxy" && echo "$STARTMSG Create SSL Certificate..." 
+        touch "$PID_CERT_CREATER.proxy" && echo "Create SSL Certificate..." 
         openssl req -x509 -newkey rsa:4096 -keyout $SSL_KEY -out $SSL_CERT -days 365 -sha256 -subj "/C=DE/CN=${MISP_FQDN}" -nodes 
-        rm $PID_CERT_CREATER.proxy
+        rm -v $PID_CERT_CREATER.proxy
     fi
     echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
@@ -46,27 +50,27 @@ SSL_generate_DH(){
     i=0
     while [ -f "$PID_CERT_CREATER.server" ]
     do
-        echo "$STARTMSG $(date +%T) -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
+        echo "$(date +%T) -  misp-server container create currently the certificate. misp-proxy until misp-server is finish."
         # added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
         i=$((i+1))
         sleep 2
-        [ "$i" -eq 30 ] && rm $PID_CERT_CREATER.server
+        [ "$i" -eq 30 ] && rm -v $PID_CERT_CREATER.server
         # END added to escape a deadlock from proxy 1.4-alpine with misp server 2.4.97-2.4.99.
     done
     
-    [ ! -f "$SSL_DH_FILE" ] && touch $PID_CERT_CREATER.proxy && echo "$STARTMSG Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
-    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    [ ! -f "$SSL_DH_FILE" ] && touch $PID_CERT_CREATER.proxy && echo "Create DH params - This can take a long time, so take a break and enjoy a cup of tea or coffee." && openssl dhparam -out $SSL_DH_FILE 2048 && rm $PID_CERT_CREATER.proxy
+    command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
 deactivate_http_config(){
-    [ -f "$HTTP_CONFIG.conf" ] && echo "mv $HTTP_CONFIG.conf $HTTP_CONFIG" && mv $HTTP_CONFIG.conf $HTTP_CONFIG
-    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    [ -f "$HTTP_CONFIG.conf" ] && echo "mv $HTTP_CONFIG.conf $HTTP_CONFIG" && mv -v $HTTP_CONFIG.conf $HTTP_CONFIG
+    command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
 activate_https_config()
 {
-    [ -f "$HTTPS_CONFIG" ] && echo "mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
-    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    [ -f "$HTTPS_CONFIG" ] && echo "mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv -v $HTTPS_CONFIG $HTTPS_CONFIG.conf
+    command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
 file_GLOBAL_allow_IPs(){
@@ -81,7 +85,7 @@ allow all;
 EOF
 else
     # If param is given include only the valid ips
-[ -f "$GLOBAL_allow_IPs" ] && rm "$GLOBAL_allow_IPs"
+[ -f "$GLOBAL_allow_IPs" ] && rm -v "$GLOBAL_allow_IPs"
 
 for i in $IP
 do
@@ -94,7 +98,7 @@ fi
 
 
 chmod 644 "$GLOBAL_allow_IPs"
-echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
 file_vars_common()
@@ -105,7 +109,7 @@ client_max_body_size $CLIENT_MAX_BODY_SIZE;
 
 EOF
 chmod 644 "$VARS_COMMON"
-echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
 }
 
 file_maintenance_html(){
@@ -133,71 +137,71 @@ cat << EOF > $MAINTENANCE_HTML_FILE
 </article>
 
 EOF
-echo
+command echo
 }
 
 enable_maintenance(){
     # deactivate https
-    [ -f "$HTTPS_CONFIG.conf" ] && echo "$STARTMSG mv $HTTPS_CONFIG.conf $HTTPS_CONFIG" && mv $HTTPS_CONFIG.conf $HTTPS_CONFIG
-    [ -f "$MAINTENANCE" ] && echo "$STARTMSG mv $MAINTENANCE $MAINTENANCE.conf" && mv $MAINTENANCE $MAINTENANCE.conf
+    [ -f "$HTTPS_CONFIG.conf" ] && echo "mv $HTTPS_CONFIG.conf $HTTPS_CONFIG" && mv -v $HTTPS_CONFIG.conf $HTTPS_CONFIG
+    [ -f "$MAINTENANCE" ] && echo "mv $MAINTENANCE $MAINTENANCE.conf" && mv -v $MAINTENANCE $MAINTENANCE.conf
     nginx -t
-    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
     exit
 }
 
 disable_maintenance(){
-    [ -f "$HTTPS_CONFIG" ] && echo "$STARTMSG mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv $HTTPS_CONFIG $HTTPS_CONFIG.conf
-    [ -f "$MAINTENANCE.conf" ] && echo "$STARTMSG mv $MAINTENANCE.conf $MAINTENANCE" && mv $MAINTENANCE.conf $MAINTENANCE
+    [ -f "$HTTPS_CONFIG" ] && echo "mv $HTTPS_CONFIG $HTTPS_CONFIG.conf" && mv -v $HTTPS_CONFIG $HTTPS_CONFIG.conf
+    [ -f "$MAINTENANCE.conf" ] && echo "mv $MAINTENANCE.conf $MAINTENANCE" && mv -v $MAINTENANCE.conf $MAINTENANCE
     nginx -t
-    echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
+    command echo # add an echo command because if no command is done busybox (alpine sh) won't continue the script
     exit
 }
 
-# upgrade(){
-#     for i in $FOLDER_with_VERSIONS
-#     do
-#         if [ ! -f "$i/${NAME}" ] 
-#         then
-#             # File not exist and now it will be created
-#             echo "${VERSION}" > "$i/${NAME}"
-#         elif [ ! -f "$i/${NAME}" ] && [ -z "$(cat "$i/${NAME}")" ]
-#         then
-#             # File exists, but is empty
-#             echo "${VERSION}" > "$i/${NAME}"
-#         elif [ "$VERSION" = "$(cat "$i/${NAME}")" ]
-#         then
-#             # File exists and the volume is the current version
-#             echo "Folder $i is on the newest version."
-#         else
-#             # upgrade
-#             echo "$STARTMSG Folder $i should be updated."
-#             case "$i/$NAME" in
-#             "1.4")
-#                 # Tasks todo in 2.4.92
-#                 echo "#### Upgrade Volumes from 2.4.92 ####"
-#                 ;;
-#             *)
-#                 echo "Unknown Version, upgrade not possible."
-#                 exit
-#                 ;;
-#             esac
-#             ############ DO ANY!!!
-#         fi
-#     done
-#     echo
-# }
+upgrade(){
+    for i in $FOLDER_with_VERSIONS
+    do
+        if [ ! -f "$i/${NAME}" ] 
+        then
+            # File not exist and now it will be created
+            command echo "${VERSION}" > "$i/${NAME}"
+        elif [ ! -f "$i/${NAME}" ] && [ -z "$(cat "$i/${NAME}")" ]
+        then
+            # File exists, but is empty
+            command echo "${VERSION}" > "$i/${NAME}"
+        elif [ "$VERSION" = "$(cat "$i/${NAME}")" ]
+        then
+            # File exists and the volume is the current version
+            command echo "Folder $i is on the newest version."
+        else
+            # upgrade
+            echo "Folder $i should be updated."
+            case "$i/$NAME" in
+            "1.4")
+                # Tasks todo in 2.4.92
+                echo "#### Upgrade Volumes from 2.4.92 ####"
+                ;;
+            *)
+                echo "Unknown Version, upgrade not possible."
+                exit
+                ;;
+            esac
+            ############ DO ANY!!!
+        fi
+    done
+    echo
+}
 
 #####################   MAIN    ###################
 # generate vars_common
-echo "$STARTMSG Create variables file..." && file_vars_common
+echo "Create variables file..." && file_vars_common
 # generate global_allow_IPs
-echo "$STARTMSG Create file for IP restrictions..." && file_GLOBAL_allow_IPs "$IP"
+echo "Create file for IP restrictions..." && file_GLOBAL_allow_IPs "$IP"
 # check if ssl cert is required to generate
-echo "$STARTMSG Check if cert is required..." && SSL_generate_cert
+echo "Check if cert is required..." && SSL_generate_cert
 # check if DH file is required to generate
-echo "$STARTMSG Check if DH is required..." && SSL_generate_DH
+echo "Check if DH is required..." && SSL_generate_DH
 # create maintenance file
-echo "$STARTMSG Create maintenance file..." && file_maintenance_html
+echo "Create maintenance file..." && file_maintenance_html
 # check volumes and upgrade if it is required
 #echo "$STARTMSG check if upgrade is required..." && upgrade
 

--- a/1.6-alpine/files/nginx/conf.d/GLOBAL_nginx_common
+++ b/1.6-alpine/files/nginx/conf.d/GLOBAL_nginx_common
@@ -1,0 +1,96 @@
+# for NGINX via Ubuntu: www-data! for NGINX vir nginx:alpine official: nginx
+user nginx;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	
+    # Enables or disables emitting nginx version in error messages and in the “Server” response header field.
+    server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# Logging Settings
+	##
+
+    log_format  main  '$host - $remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+    
+	#access_log /var/log/nginx/access.log;
+	access_log /dev/stdout main;
+	#error_log /var/log/nginx/error.log;
+	error_log /dev/stderr;
+	#access_log  /var/log/nginx/access_main__log_format.log  main;
+
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_http_version 1.1;
+
+    # Enables gzipping of responses for the specified MIME types in addition to “text/html”. 
+    # The special value “*” matches any MIME type (0.8.29). 
+    # Responses with the “text/html” type are always compressed.
+    gzip_types text/css text/javascript application/x-javascript application/javascript application/atom+xml application/json application/xml text/xml image/x-icon ;
+
+    # Sets the minimum length of a response that will be gzipped. 
+    # The length is determined only from the “Content-Length” response header field.
+    gzip_min_length  0;
+
+    # Sets a gzip compression level of a response. Acceptable values are in the range from 1 to 9.
+    gzip_comp_level 2;
+
+    # Sets the number and size of buffers used to compress a response. 
+    # By default, the buffer size is equal to one memory page. 
+    # This is either 4K or 8K, depending on a platform.
+    gzip_buffers 32 8k;
+
+    # Enables or disables gzipping of responses for proxied requests depending on the request and response. 
+    # The fact that the request is proxied is determined by the presence of the “Via” request header field. 
+    # The directive accepts multiple parameters:
+    gzip_proxied any;     
+
+    # Enables or disables inserting the “Vary: Accept-Encoding” response header field if the directives gzip, gzip_static, or gunzip are active.
+    gzip_vary on;
+
+	##
+	# IP Whitelisting
+	##
+
+    # Whitelist only IPs from GLOBAL_allow_IPs file and deny all other:
+    include /etc/nginx/conf.d/GLOBAL_allow_IPs;
+    deny all;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	#include /etc/nginx/sites-enabled/*;
+}
+

--- a/1.6-alpine/files/nginx/conf.d/GLOBAL_ssl_common.conf
+++ b/1.6-alpine/files/nginx/conf.d/GLOBAL_ssl_common.conf
@@ -1,0 +1,24 @@
+#   Global SSL Parameters
+#==============================
+
+# certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:50m;
+ssl_session_tickets off;
+
+# Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+ssl_dhparam /etc/nginx/ssl/dhparams.pem;
+
+# intermediate configuration. tweak to your needs.
+ssl_protocols TLSv1.2;
+ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!3DES';
+ssl_prefer_server_ciphers on;
+
+# HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months / 86400 seconds = 60 days)
+#add_header Strict-Transport-Security "max-age=86400; includeSubDomains" always;
+
+# OCSP Stapling ---
+# fetch OCSP records from URL in ssl_certificate and cache them
+#ssl_stapling on;
+#ssl_stapling_verify on;
+#resolver 8.8.8.8 8.8.4.4;

--- a/1.6-alpine/files/nginx/conf.d/SERVER_HTTPS_and_redirected_HTTP.conf
+++ b/1.6-alpine/files/nginx/conf.d/SERVER_HTTPS_and_redirected_HTTP.conf
@@ -1,0 +1,24 @@
+# HTTP Config to redirect traffic to HTTPS
+server {
+	listen 80;
+	include conf.d/vars_common;
+
+	# redirect to HTTPS
+	return 301 https://$host$request_uri;
+
+}
+
+# HTTPS Config to Proxy traffic to misp-server
+server {
+	listen 443 ssl http2;
+
+	include conf.d/vars_common;
+
+	ssl_certificate /etc/nginx/ssl/cert.pem;
+	ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+	location / {
+		include conf.d/misp_vars_proxy;
+	}
+	
+}

--- a/1.6-alpine/files/nginx/conf.d/SERVER_MAINTENANCE
+++ b/1.6-alpine/files/nginx/conf.d/SERVER_MAINTENANCE
@@ -1,0 +1,13 @@
+# HTTP / HTTPS Config for maintenance
+server {
+	listen 80;
+	listen 443 ssl http2;
+	include conf.d/vars_common;
+
+	# SSL Certificate and Key
+	ssl_certificate /etc/nginx/ssl/cert.pem;
+	ssl_certificate_key /etc/nginx/ssl/key.pem;
+
+	root /var/www/maintenance;	
+	index index.html;
+}

--- a/1.6-alpine/files/nginx/conf.d/misp_vars_proxy
+++ b/1.6-alpine/files/nginx/conf.d/misp_vars_proxy
@@ -1,0 +1,47 @@
+#   Proxy Include File
+#==============================
+
+# Sets the protocol and address of a proxied server and an optional URI to which a location should be mapped. 
+# As a protocol, “http” or “https” can be specified. 
+# The address can be specified as a domain name or IP address, and an optional port:
+proxy_pass https://misp-server:443;
+
+# Allows redefining or appending fields to the request header passed to the proxied server. 
+# The value can contain text, variables, and their combinations. 
+# These directives are inherited from the previous level if and 
+# only if there are no proxy_set_header directives defined on the current level. 
+# By default, only two fields are redefined:
+#   proxy_set_header Host       $proxy_host;
+#   proxy_set_header Connection close;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection "";
+
+proxy_buffering off;
+proxy_request_buffering off;
+proxy_intercept_errors on;
+
+# Determines whether SSL sessions can be reused when working with the proxied server. 
+# If the errors “SSL3_GET_FINISHED:digest check failed” appear in the logs, 
+# try disabling session reuse. Default:
+# proxy_ssl_session_reuse on;
+
+# Sets the HTTP protocol version for proxying. 
+# By default, version 1.0 is used. 
+# Version 1.1 is recommended for use with keepalive connections and NTLM authentication.
+proxy_http_version 1.1;
+
+# Defines a timeout for reading a response from the proxied server. 
+# The timeout is set only between two successive read operations, not for the transmission of the whole response. 
+# If the proxied server does not transmit anything within this time, the connection is closed.
+proxy_read_timeout 300;		
+
+# Adds the specified field to a response header provided that the response code equals 
+# 200, 201 (1.3.10), 204, 206, 301, 302, 303, 304, 307 (1.1.16, 1.0.13), or 308 (1.13.0). 
+# The value can contain variables.
+# If the always parameter is specified (1.7.5), the header field will be added regardless of the response code
+add_header Cache-Control "public, must-revalidate";
+

--- a/1.6-alpine/files/nginx/conf.d/monitoring_vars_proxy
+++ b/1.6-alpine/files/nginx/conf.d/monitoring_vars_proxy
@@ -1,0 +1,20 @@
+#   Proxy Include File
+#==============================
+
+# Documentation: https://github.com/firehol/netdata/wiki/Running-behind-nginx
+
+proxy_redirect off;
+proxy_set_header Host $host;
+
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Server $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_http_version 1.1;
+proxy_pass_request_headers on;
+proxy_set_header Connection "keep-alive";
+proxy_store off;
+proxy_pass http://misp-server:19999/$ndpath$is_args$args;
+
+gzip on;
+gzip_proxied any;
+gzip_types *;


### PR DESCRIPTION
## Bug/MDD 226: MISP Proxy Version 1 (1.5-alpine) can not start with MISP-dockerized 1.0.3
### Update Information
This release added a new MISP proxy container: `misp-dockerized-proxy:1.6-alpine`. Which fixes an bug from 1.5-alpine.
### General Changes
- For performance reasons Gitlab CI is now disabled for the build. Only Travis CI build the container. 
### Fixes and Improvements
- Added a new 1.6-alpine container for MISP-dockerized 1.0.3 and below
### Detailed Changes
- Added a new 1.6-alpine container for MISP-dockerized 1.0.3 and below
  The 1.5-alpine container logs:
   ```bash
   2019/07/30 08:21:05 [emerg] 21#21: invalid number of arguments in "server_name" directive in /etc/nginx/conf.d/vars_common:1
   nginx: [emerg] invalid number of arguments in "server_name" directive in /etc/nginx/conf.d/vars_common:1
   nginx: configuration file /etc/nginx/nginx.conf test failed
   ``` 
   This comes from an unfilled environment variable. We fixed this and from now on if the environment variable `MISP_FQDN` is empty the entrypoint script fill it with the `HOSTNAME` variable. Which is filled automatically from docker itself.